### PR TITLE
Bump bech32 to 0.8.0 and use BIP-0350 Bech32m checksum

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ secp-lowmemory = ["secp256k1/lowmemory"]
 secp-recovery = ["secp256k1/recovery"]
 
 [dependencies]
-bech32 = "0.7.2"
+bech32 = "0.8.0"
 bitcoin_hashes = "0.9.1"
 secp256k1 = "0.20.0"
 


### PR DESCRIPTION
Replace BIP-0173 test vectors with those in BIP-0350.